### PR TITLE
Performance boost in Repository

### DIFF
--- a/EventSourcingDemo/Repository/Repository.cs
+++ b/EventSourcingDemo/Repository/Repository.cs
@@ -1,13 +1,9 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using EventSourcingDemo.Domain;
-using EventSourcingDemo.Events;
+﻿using EventSourcingDemo.Domain;
 using EventSourcingDemo.Exceptions;
 using EventSourcingDemo.Snapshot;
 using EventSourcingDemo.Storage;
+using System;
+using System.Linq;
 
 namespace EventSourcingDemo.Repository
 {
@@ -15,10 +11,13 @@ namespace EventSourcingDemo.Repository
     {
         private readonly IEventStorageProvider _EventStorageProvider;
         private readonly ISnapshotStorageProvider _SnapshotStorageProvider;
-        private static object syncLockObject = new object();
+        private static object syncLockObject;
 
         public Repository(IEventStorageProvider eventStorageProvider, ISnapshotStorageProvider snapshotStorageProvider)
         {
+            if (!eventStorageProvider.HasConcurrencyCheck)
+                syncLockObject = new object();
+
             _EventStorageProvider = eventStorageProvider;
             _SnapshotStorageProvider = snapshotStorageProvider;
         }
@@ -27,32 +26,38 @@ namespace EventSourcingDemo.Repository
         {
             if (aggregate.GetUncommittedChanges().Any())
             {
-                lock (syncLockObject)
+                if (_EventStorageProvider.HasConcurrencyCheck)
+                    this.DoSave(aggregate);
+                else
+                    lock (syncLockObject)
+                        this.DoSave(aggregate);
+            }
+        }
+
+        private void DoSave(AggregateRoot aggregate)
+        {
+            var item = new T();
+            var expectedVersion = aggregate.LastCommittedVersion;
+
+            if (expectedVersion != 0)
+            {
+                item = GetById(aggregate.Id);
+                if (item.CurrentVersion != expectedVersion)
                 {
-                    var item = new T();
-                    var expectedVersion = aggregate.LastCommittedVersion;
-
-                    if (expectedVersion != 0)
-                    {
-                        item = GetById(aggregate.Id);
-                        if (item.CurrentVersion != expectedVersion)
-                        {
-                            throw new ConcurrencyException($"Aggregate {item.Id} has been modified externally and has an updated state. Can't commit changes.");
-                        }
-                    }
-
-                    _EventStorageProvider.CommitChanges(aggregate);
-
-                    //Every 3 events we save a snapshot
-                    if ((aggregate.CurrentVersion > 2) &&
-                        (aggregate.CurrentVersion - aggregate.LastCommittedVersion > 3) || (aggregate.CurrentVersion % 3 == 0))
-                    {
-                        _SnapshotStorageProvider.SaveSnapshot(((ISnapshottable)aggregate).GetSnapshot());
-                    }
-
-                    aggregate.MarkChangesAsCommitted();
+                    throw new ConcurrencyException($"Aggregate {item.Id} has been modified externally and has an updated state. Can't commit changes.");
                 }
             }
+
+            _EventStorageProvider.CommitChanges(aggregate);
+
+            //Every 3 events we save a snapshot
+            if ((aggregate.CurrentVersion > 2) &&
+                (aggregate.CurrentVersion - aggregate.LastCommittedVersion > 3) || (aggregate.CurrentVersion % 3 == 0))
+            {
+                _SnapshotStorageProvider.SaveSnapshot(((ISnapshottable)aggregate).GetSnapshot());
+            }
+
+            aggregate.MarkChangesAsCommitted();
         }
 
         public T GetById(Guid id)

--- a/EventSourcingDemo/Storage/IEventStorageProvider.cs
+++ b/EventSourcingDemo/Storage/IEventStorageProvider.cs
@@ -1,12 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Security.Cryptography.X509Certificates;
-using System.Text;
-using System.Threading.Tasks;
-using EventSourcingDemo.Domain;
+﻿using EventSourcingDemo.Domain;
 using EventSourcingDemo.Events;
-using EventSourcingDemo.Snapshot;
+using System;
+using System.Collections.Generic;
 
 namespace EventSourcingDemo.Storage
 {
@@ -14,6 +9,7 @@ namespace EventSourcingDemo.Storage
     {
         IEnumerable<Event> GetEvents(Guid aggregateId, int start, int end);
         void CommitChanges(AggregateRoot aggregate);
+        bool HasConcurrencyCheck { get; }
     }
 }
 

--- a/EventSourcingDemo/Storage/InMemoryEventStorageProvider.cs
+++ b/EventSourcingDemo/Storage/InMemoryEventStorageProvider.cs
@@ -1,20 +1,18 @@
-﻿using System;
-using System.Collections;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using EventSourcingDemo.Domain;
+﻿using EventSourcingDemo.Domain;
 using EventSourcingDemo.Events;
 using EventSourcingDemo.Exceptions;
-using EventSourcingDemo.Snapshot;
+using System;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace EventSourcingDemo.Storage
 {
     class InMemoryEventStorageProvider : IEventStorageProvider
     {
         private Dictionary<Guid, List<Event>> eventStream = new Dictionary<Guid, List<Event>>();
-        
+
+        public bool HasConcurrencyCheck => false;
+
         public IEnumerable<Event> GetEvents(Guid aggregateId, int start, int end)
         {
             try


### PR DESCRIPTION
Removed unnecessary lock in the repository and added as an option for storage providers that does not have concurrency checks built in. This should improve performance for high contention scenarios.