### PR TITLE
MasterSession to manage multiple Aggregate types

### DIFF
--- a/src/Extensions/NEventLite.Extensions.Autofac/Extensions.cs
+++ b/src/Extensions/NEventLite.Extensions.Autofac/Extensions.cs
@@ -9,20 +9,33 @@ namespace NEventLite.Extensions.Autofac
 {
     public static class Extensions
     {
-        public static void ScanAndRegisterAggregates(this ContainerBuilder services)
+        public static ContainerBuilder RegisterMasterSession(this ContainerBuilder services)
         {
-            services.ScanAndRegisterAggregates(AppDomain.CurrentDomain.GetAssemblies());
+            services.Register(c => new MasterSession.ServiceFactory(c.Resolve))
+                .InstancePerLifetimeScope();
+            services.RegisterType<MasterSession>().As<IMasterSession>()
+                .InstancePerLifetimeScope();
+
+            return services;
         }
 
-        public static void ScanAndRegisterAggregates(this ContainerBuilder services, IList<Assembly> assemblies)
+        public static ContainerBuilder ScanAndRegisterAggregates(this ContainerBuilder services)
+        {
+            services.ScanAndRegisterAggregates(AppDomain.CurrentDomain.GetAssemblies());
+            return services;
+        }
+
+        public static ContainerBuilder ScanAndRegisterAggregates(this ContainerBuilder services, IList<Assembly> assemblies)
         {
             foreach (var a in assemblies.GetAllAggregates())
             {
                 services.RegisterAggregate(a);
             }
+
+            return services;
         }
 
-        public static void RegisterAggregate(this ContainerBuilder services, AggregateInformation a)
+        public static ContainerBuilder RegisterAggregate(this ContainerBuilder services, AggregateInformation a)
         {
             // Register full generic types
             services.RegisterType(a.Snapshot != null
@@ -42,6 +55,8 @@ namespace NEventLite.Extensions.Autofac
                     .As(typeof(ISession<>).MakeGenericType(a.Aggregate))
                     .InstancePerLifetimeScope();
             }
+
+            return services;
         }
     }
 }

--- a/src/Extensions/NEventLite.Extensions.Autofac/Extensions.cs
+++ b/src/Extensions/NEventLite.Extensions.Autofac/Extensions.cs
@@ -17,6 +17,7 @@ namespace NEventLite.Extensions.Autofac
                     return new MasterSession.ServiceFactory(context.Resolve);
                 })
                 .InstancePerLifetimeScope();
+
             services.RegisterType<MasterSession>().As<IMasterSession>()
                 .InstancePerLifetimeScope();
 

--- a/src/Extensions/NEventLite.Extensions.Autofac/Extensions.cs
+++ b/src/Extensions/NEventLite.Extensions.Autofac/Extensions.cs
@@ -11,7 +11,11 @@ namespace NEventLite.Extensions.Autofac
     {
         public static ContainerBuilder RegisterMasterSession(this ContainerBuilder services)
         {
-            services.Register(c => new MasterSession.ServiceFactory(c.Resolve))
+            services.Register(c =>
+                {
+                    var context = c.Resolve<IComponentContext>();
+                    return new MasterSession.ServiceFactory(context.Resolve);
+                })
                 .InstancePerLifetimeScope();
             services.RegisterType<MasterSession>().As<IMasterSession>()
                 .InstancePerLifetimeScope();

--- a/src/Extensions/NEventLite.Extensions.Microsoft.DependencyInjection/Extensions.cs
+++ b/src/Extensions/NEventLite.Extensions.Microsoft.DependencyInjection/Extensions.cs
@@ -9,20 +9,30 @@ namespace NEventLite.Extensions.Microsoft.DependencyInjection
 {
     public static class Extensions
     {
-        public static void ScanAndRegisterAggregates(this ServiceCollection services)
+        public static ServiceCollection RegisterMasterSession(this ServiceCollection services)
         {
-            services.ScanAndRegisterAggregates(AppDomain.CurrentDomain.GetAssemblies());
+            services.AddScoped(sp => new MasterSession.ServiceFactory(sp.GetService));
+            services.AddScoped<IMasterSession, MasterSession>();
+
+            return services;
         }
 
-        public static void ScanAndRegisterAggregates(this ServiceCollection services, IList<Assembly> assemblies)
+        public static ServiceCollection ScanAndRegisterAggregates(this ServiceCollection services)
+        {
+            return services.ScanAndRegisterAggregates(AppDomain.CurrentDomain.GetAssemblies());
+        }
+
+        public static ServiceCollection ScanAndRegisterAggregates(this ServiceCollection services, IList<Assembly> assemblies)
         {
             foreach (var a in assemblies.GetAllAggregates())
             {
                 services.RegisterAggregate(a);
             }
+
+            return services;
         }
 
-        public static void RegisterAggregate(this ServiceCollection services, AggregateInformation a)
+        public static ServiceCollection RegisterAggregate(this ServiceCollection services, AggregateInformation a)
         {
             // Register full generic types
             services.AddScoped(typeof(IRepository<,,>).MakeGenericType(a.Aggregate, a.AggregateKey, a.EventKey),
@@ -40,6 +50,8 @@ namespace NEventLite.Extensions.Microsoft.DependencyInjection
                 services.AddScoped(typeof(ISession<>).MakeGenericType(a.Aggregate),
                     typeof(Session<>).MakeGenericType(a.Aggregate));
             }
+
+            return services;
         }
     }
 }

--- a/src/NEventLite.Tests.Integration/MasterSessionTests.cs
+++ b/src/NEventLite.Tests.Integration/MasterSessionTests.cs
@@ -1,0 +1,185 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using NEventLite.Core;
+using NEventLite.Core.Domain;
+using NEventLite.Repository;
+using NEventLite.Samples.Common.Domain.Schedule;
+using NEventLite.Samples.Common.Domain.Schedule.Snapshots;
+using NEventLite.Storage;
+using NEventLite.StorageProviders.InMemory;
+using NEventLite.Tests.Integration.Mocks;
+using Shouldly;
+using Xunit;
+
+namespace NEventLite.Tests.Integration
+{
+    public class MasterSessionTests
+    {
+        private class MockObject : IAggregateRoot
+        {
+        }
+
+        private readonly MockEventPublisher _eventPublisher;
+        private readonly MockClock _clock;
+        private readonly IRepository<Schedule, Guid, Guid> _repository;
+        private readonly IRepository<Schedule, Guid, Guid> _eventOnlyRepository;
+        const int SnapshotFrequency = 2;
+
+        public MasterSessionTests()
+        {
+            //This path is used to save in memory storage
+            var strTempDataFolderPath = AppDomain.CurrentDomain.BaseDirectory + @"App_Data\";
+
+            //create temp directory if it doesn't exist
+            new FileInfo(strTempDataFolderPath).Directory?.Create();
+
+            var inMemoryEventStorePath = $@"{strTempDataFolderPath}events.stream.dump";
+            var inMemorySnapshotStorePath = $@"{strTempDataFolderPath}events.snapshot.dump";
+
+            File.Delete(inMemoryEventStorePath);
+            File.Delete(inMemorySnapshotStorePath);
+
+            IEventStorageProvider<Guid> eventStorage =
+                new InMemoryEventStorageProvider(inMemoryEventStorePath);
+
+            ISnapshotStorageProvider<Guid> snapshotStorage =
+                new InMemorySnapshotStorageProvider(SnapshotFrequency, inMemorySnapshotStorePath);
+
+            _clock = new MockClock();
+            _eventPublisher = new MockEventPublisher();
+            _repository = new Repository<Schedule, ScheduleSnapshot, Guid, Guid, Guid>(_clock, eventStorage, _eventPublisher, snapshotStorage);
+            _eventOnlyRepository = new EventOnlyRepository<Schedule, Guid, Guid>(_clock, eventStorage, _eventPublisher);
+        }
+
+        [Fact]
+        public async Task WhenCreatingSchedule_ItGetsCreated_AndCanBe_ReloadedFromTheRepository()
+        {
+            Func<Type, object> factory = (t) =>
+            {
+                if (t == typeof(IRepository<Schedule, Guid, Guid>))
+                {
+                    return _repository;
+                }
+
+                throw new Exception("Invalid type requested");
+            };
+
+            using (var session = new MasterSession(new MasterSession.ServiceFactory(factory)))
+            {
+                var scheduleName = "test schedule";
+                var schedule = new Schedule(scheduleName);
+                session.Attach(schedule);
+                await session.SaveAsync();
+                session.DetachAll();
+
+                var reloadedSchedule = await session.GetByIdAsync<Schedule>(schedule.Id);
+                reloadedSchedule.Id.ShouldBe(schedule.Id);
+                reloadedSchedule.ScheduleName.ShouldBe(scheduleName);
+                reloadedSchedule.StreamState.ShouldBe(StreamState.HasStream);
+                reloadedSchedule.CurrentVersion.ShouldBe(0);
+                reloadedSchedule.LastCommittedVersion.ShouldBe(0);
+
+                var events = _eventPublisher.Events[reloadedSchedule.Id];
+                events.Count.ShouldBe(1);
+                events.First().EventCommittedTimestamp.ShouldBe(_clock.Value);
+            }
+        }
+
+        [Fact]
+        public async Task WhenCreatingSchedule_ItGetsCreated_AndCanBe_ReloadedFromTheEventOnlyRepository()
+        {
+            Func<Type, object> factory = (t) =>
+            {
+                if (t == typeof(IRepository<Schedule, Guid, Guid>))
+                {
+                    return _eventOnlyRepository;
+                }
+
+                throw new Exception("Invalid type requested");
+            };
+
+            using (var session = new MasterSession(new MasterSession.ServiceFactory(factory)))
+            {
+                var scheduleName = "test schedule";
+                var schedule = new Schedule(scheduleName);
+                session.Attach(schedule);
+                await session.SaveAsync();
+                session.DetachAll();
+
+                var reloadedSchedule = await session.GetByIdAsync<Schedule>(schedule.Id);
+                reloadedSchedule.Id.ShouldBe(schedule.Id);
+                reloadedSchedule.ScheduleName.ShouldBe(scheduleName);
+                reloadedSchedule.StreamState.ShouldBe(StreamState.HasStream);
+                reloadedSchedule.CurrentVersion.ShouldBe(0);
+                reloadedSchedule.LastCommittedVersion.ShouldBe(0);
+
+                var events = _eventPublisher.Events[reloadedSchedule.Id];
+                events.Count.ShouldBe(1);
+                events.First().EventCommittedTimestamp.ShouldBe(_clock.Value);
+            }
+        }
+
+        [Fact]
+        public void WhenCreatingSchedule_MasterSessionThrowException_IfInvalidAggregateTypeIsPassed()
+        {
+            Func<Type, object> factory = (t) => throw new Exception("Invalid type requested");
+
+            using (var session = new MasterSession(new MasterSession.ServiceFactory(factory)))
+            {
+                Should.Throw<ArgumentException>(() =>
+                {
+                    session.Attach(new MockObject());
+                });
+            }
+        }
+
+        [Fact]
+        public void WhenCreatingSchedule_MasterSessionThrowException_IfNoRepositoryIsFound()
+        {
+            Func<Type, object> factory = (t) => null;
+
+            using (var session = new MasterSession(new MasterSession.ServiceFactory(factory)))
+            {
+                var scheduleName = "test schedule";
+                var schedule = new Schedule(scheduleName);
+
+                Should.Throw<ArgumentException>(() =>
+                {
+                    session.Attach(schedule);
+                });
+            }
+        }
+
+        [Fact]
+        public async Task WhenCreatingSchedule_MasterSessionThrowException_IfInvalidIdTypeIsPassed()
+        {
+            Func<Type, object> factory = (t) =>
+            {
+                if (t == typeof(IRepository<Schedule, Guid, Guid>))
+                {
+                    return _repository;
+                }
+
+                throw new Exception("Invalid type requested");
+            };
+
+            using (var session = new MasterSession(new MasterSession.ServiceFactory(factory)))
+            {
+                var scheduleName = "test schedule";
+                var schedule = new Schedule(scheduleName);
+                session.Attach(schedule);
+                await session.SaveAsync();
+                session.DetachAll();
+
+                await Should.ThrowAsync<ArgumentException>(async () =>
+                {
+                    await session.GetByIdAsync<Schedule>(schedule.Id.ToString());
+                });
+            }
+        }
+    }
+}

--- a/src/NEventLite/Repository/IMasterSession.cs
+++ b/src/NEventLite/Repository/IMasterSession.cs
@@ -1,0 +1,14 @@
+﻿using System.Threading.Tasks;
+using NEventLite.Core.Domain;
+
+namespace NEventLite.Repository
+{
+    public interface IMasterSession
+    {
+        Task<TAggregate> GetByIdAsync<TAggregate>(object id) where TAggregate: IAggregateRoot;
+        void Attach<TAggregate>(TAggregate aggregate) where TAggregate : IAggregateRoot;
+        void Detach<TAggregate>(TAggregate aggregate) where TAggregate : IAggregateRoot;
+        Task SaveAsync();
+        void DetachAll();
+    }
+}

--- a/src/NEventLite/Repository/IMasterSession.cs
+++ b/src/NEventLite/Repository/IMasterSession.cs
@@ -1,11 +1,12 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Threading.Tasks;
 using NEventLite.Core.Domain;
 
 namespace NEventLite.Repository
 {
-    public interface IMasterSession
+    public interface IMasterSession : IDisposable
     {
-        Task<TAggregate> GetByIdAsync<TAggregate>(object id) where TAggregate: IAggregateRoot;
+        Task<TAggregate> GetByIdAsync<TAggregate>(object id) where TAggregate : IAggregateRoot;
         void Attach<TAggregate>(TAggregate aggregate) where TAggregate : IAggregateRoot;
         void Detach<TAggregate>(TAggregate aggregate) where TAggregate : IAggregateRoot;
         Task SaveAsync();

--- a/src/NEventLite/Repository/MasterSession.cs
+++ b/src/NEventLite/Repository/MasterSession.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
@@ -11,16 +12,29 @@ namespace NEventLite.Repository
 {
     public class MasterSession : IMasterSession
     {
-        public delegate object ServiceFactory(Type type); 
+        public delegate object ServiceFactory(Type type);
 
-        private sealed class MockAggregate : AggregateRoot
+        private class MockAggregate : AggregateRoot
         {
         }
 
-        private readonly Dictionary<Type, Func<object, object>> _repositoryGetByIdMethods = new Dictionary<Type, Func<object, object>>();
-        private readonly Dictionary<Type, Func<object, Task>> _repositorySaveMethods = new Dictionary<Type, Func<object, Task>>();
-        private readonly Dictionary<Type, AggregateInformation> _aggregateInformationCache = new Dictionary<Type, AggregateInformation>();
-        private readonly Dictionary<Type, Dictionary<object, object>> _allTrackedItems = new Dictionary<Type, Dictionary<object, object>>(); // type, key, value
+        private class AggregateTypeContainer
+        {
+            public AggregateInformation AggregateInformation { get; }
+            public Func<object, object> GetByIdMethod { get; }
+            public Func<object, Task> RepositorySaveMethod { get; }
+            public Dictionary<object, object> TrackedItems { get; } =
+                new Dictionary<object, object>(); // key, value of id, aggregate
+
+            public AggregateTypeContainer(AggregateInformation aggregateInformation, Func<object, object> byIdMethod, Func<object, Task> repositorySaveMethod)
+            {
+                AggregateInformation = aggregateInformation;
+                GetByIdMethod = byIdMethod;
+                RepositorySaveMethod = repositorySaveMethod;
+            }
+        }
+
+        private readonly Dictionary<Type, AggregateTypeContainer> _aggregateTypeContainerCache = new Dictionary<Type, AggregateTypeContainer>();
         private readonly ServiceFactory _factory;
 
         private readonly SemaphoreSlim _syncLock = new SemaphoreSlim(1, 1);
@@ -39,20 +53,20 @@ namespace NEventLite.Repository
                 var aggregateType = typeof(TAggregate);
                 SetupAggregateInfo(aggregateType);
 
-                var aggregateInfo = _aggregateInformationCache[aggregateType];
-                if (aggregateInfo.AggregateKey != id.GetType())
+                var typeContainer = _aggregateTypeContainerCache[aggregateType];
+                if (typeContainer.AggregateInformation.AggregateKey != id.GetType())
                 {
-                    throw new ArgumentException($"Id is not of type {aggregateInfo.AggregateKey.Name}", nameof(id));
+                    throw new ArgumentException($"Id is not of type {typeContainer.AggregateInformation.AggregateKey.Name}", nameof(id));
                 }
 
-                var itemExists = _allTrackedItems[aggregateType].TryGetValue(id, out var result);
+                var itemExists = typeContainer.TrackedItems.TryGetValue(id, out var result);
                 if (itemExists)
                 {
                     return (TAggregate)result;
                 }
 
-                result = await (Task<TAggregate>)_repositoryGetByIdMethods[aggregateType](id);
-                _allTrackedItems[aggregateType].Add(id, result);
+                result = await (Task<TAggregate>)typeContainer.GetByIdMethod(id);
+                typeContainer.TrackedItems.Add(id, result);
 
                 return (TAggregate)result;
             }
@@ -72,14 +86,15 @@ namespace NEventLite.Repository
                 SetupAggregateInfo(aggregateType);
 
                 var id = GetId(aggregate);
+                var typeContainer = _aggregateTypeContainerCache[aggregateType];
 
-                var itemExists = _allTrackedItems[aggregateType].TryGetValue(id, out var result);
+                var itemExists = typeContainer.TrackedItems.TryGetValue(id, out _);
                 if (itemExists)
                 {
                     throw new ArgumentException("Item with the same id is already tracked", nameof(aggregate));
                 }
 
-                _allTrackedItems[aggregateType].Add(id, aggregate);
+                typeContainer.TrackedItems.Add(id, aggregate);
             }
             finally
             {
@@ -97,11 +112,12 @@ namespace NEventLite.Repository
                 SetupAggregateInfo(aggregateType);
 
                 var id = GetId(aggregate);
+                var typeContainer = _aggregateTypeContainerCache[aggregateType];
 
-                var itemExists = _allTrackedItems[aggregateType].TryGetValue(id, out var result);
+                var itemExists = typeContainer.TrackedItems.TryGetValue(id, out var result);
                 if (itemExists)
                 {
-                    _allTrackedItems[aggregateType].Remove(id);
+                    typeContainer.TrackedItems.Remove(id);
                 }
                 else
                 {
@@ -120,12 +136,13 @@ namespace NEventLite.Repository
 
             try
             {
-                foreach (var t in _allTrackedItems)
+                foreach (var t in _aggregateTypeContainerCache)
                 {
-                    var saveMethod = _repositorySaveMethods[t.Key];
-                    foreach (var keyValuePair in t.Value)
+                    var typeContainer = t.Value;
+                    var saveMethod = typeContainer.RepositorySaveMethod;
+                    foreach (var keyValuePair in typeContainer.TrackedItems)
                     {
-                        await (Task)saveMethod(keyValuePair.Value);
+                        await saveMethod(keyValuePair.Value);
                     }
                 }
             }
@@ -141,9 +158,9 @@ namespace NEventLite.Repository
 
             try
             {
-                foreach (var t in _allTrackedItems)
+                foreach (var t in _aggregateTypeContainerCache)
                 {
-                    t.Value.Clear();
+                    t.Value.TrackedItems.Clear();
                 }
             }
             finally
@@ -154,7 +171,7 @@ namespace NEventLite.Repository
 
         private void SetupAggregateInfo(Type aggregateType)
         {
-            if (_aggregateInformationCache.ContainsKey(aggregateType))
+            if (_aggregateTypeContainerCache.ContainsKey(aggregateType))
             {
                 return;
             }
@@ -165,8 +182,7 @@ namespace NEventLite.Repository
                 throw new ArgumentException("The type is not a valid AggregateType", nameof(aggregateType));
             }
 
-            var repositoryType =
-                typeof(IRepository<,,>).MakeGenericType(result.Aggregate, result.AggregateKey, result.EventKey);
+            var repositoryType = typeof(IRepository<,,>).MakeGenericType(result.Aggregate, result.AggregateKey, result.EventKey);
             var repository = _factory(repositoryType);
 
             if (repository == null)
@@ -176,26 +192,33 @@ namespace NEventLite.Repository
 
             repository = repositoryType.Cast(repository); // convert to type of interface
 
-            _aggregateInformationCache.Add(aggregateType, result);
-            _repositoryGetByIdMethods.Add(aggregateType, id =>
-                {
-                    var genericMethod = repositoryType.GetMethod(nameof(IRepository<MockAggregate, Guid, Guid>.GetByIdAsync));
-                    return genericMethod.Invoke(repository, new[] { id });
-                });
+            Func<object, object> getByIdMethodAsync = (id) =>
+            {
+                var genericMethod =
+                    repositoryType.GetMethod(nameof(IRepository<MockAggregate, Guid, Guid>.GetByIdAsync));
+                return genericMethod.Invoke(repository, new[] { id });
+            }; // returns Task<TAggregate>
 
-            _repositorySaveMethods.Add(aggregateType, aggregate =>
+            Func<object, Task> saveMethodAsync = (aggregate) =>
             {
                 var genericMethod = repositoryType.GetMethod(nameof(IRepository<MockAggregate, Guid, Guid>.SaveAsync));
                 return (Task)genericMethod.Invoke(repository, new[] { aggregate });
-            });
+            }; // returns Task
 
-            _allTrackedItems.Add(aggregateType, new Dictionary<object, object>());
+            _aggregateTypeContainerCache.Add(result.Aggregate,
+                new AggregateTypeContainer(result, getByIdMethodAsync, saveMethodAsync));
         }
 
         private static object GetId<TAggregate>(TAggregate aggregate) where TAggregate : IAggregateRoot
         {
             var id = typeof(TAggregate).GetProperty(nameof(MockAggregate.Id)).GetMethod.Invoke(aggregate, null);
             return id;
+        }
+
+        public void Dispose()
+        {
+            _aggregateTypeContainerCache.Clear();
+            _syncLock?.Dispose();
         }
     }
 }

--- a/src/NEventLite/Repository/MasterSession.cs
+++ b/src/NEventLite/Repository/MasterSession.cs
@@ -1,0 +1,201 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using NEventLite.Core.Domain;
+using NEventLite.Util;
+
+namespace NEventLite.Repository
+{
+    public class MasterSession : IMasterSession
+    {
+        public delegate object ServiceFactory(Type type); 
+
+        private sealed class MockAggregate : AggregateRoot
+        {
+        }
+
+        private readonly Dictionary<Type, Func<object, object>> _repositoryGetByIdMethods = new Dictionary<Type, Func<object, object>>();
+        private readonly Dictionary<Type, Func<object, Task>> _repositorySaveMethods = new Dictionary<Type, Func<object, Task>>();
+        private readonly Dictionary<Type, AggregateInformation> _aggregateInformationCache = new Dictionary<Type, AggregateInformation>();
+        private readonly Dictionary<Type, Dictionary<object, object>> _allTrackedItems = new Dictionary<Type, Dictionary<object, object>>(); // type, key, value
+        private readonly ServiceFactory _factory;
+
+        private readonly SemaphoreSlim _syncLock = new SemaphoreSlim(1, 1);
+
+        public MasterSession(ServiceFactory factory)
+        {
+            _factory = factory;
+        }
+
+        public async Task<TAggregate> GetByIdAsync<TAggregate>(object id) where TAggregate : IAggregateRoot
+        {
+            await _syncLock.WaitAsync();
+
+            try
+            {
+                var aggregateType = typeof(TAggregate);
+                SetupAggregateInfo(aggregateType);
+
+                var aggregateInfo = _aggregateInformationCache[aggregateType];
+                if (aggregateInfo.AggregateKey != id.GetType())
+                {
+                    throw new ArgumentException($"Id is not of type {aggregateInfo.AggregateKey.Name}", nameof(id));
+                }
+
+                var itemExists = _allTrackedItems[aggregateType].TryGetValue(id, out var result);
+                if (itemExists)
+                {
+                    return (TAggregate)result;
+                }
+
+                result = await (Task<TAggregate>)_repositoryGetByIdMethods[aggregateType](id);
+                _allTrackedItems[aggregateType].Add(id, result);
+
+                return (TAggregate)result;
+            }
+            finally
+            {
+                _syncLock.Release();
+            }
+        }
+
+        public void Attach<TAggregate>(TAggregate aggregate) where TAggregate : IAggregateRoot
+        {
+            _syncLock.Wait();
+
+            try
+            {
+                var aggregateType = typeof(TAggregate);
+                SetupAggregateInfo(aggregateType);
+
+                var id = GetId(aggregate);
+
+                var itemExists = _allTrackedItems[aggregateType].TryGetValue(id, out var result);
+                if (itemExists)
+                {
+                    throw new ArgumentException("Item with the same id is already tracked", nameof(aggregate));
+                }
+
+                _allTrackedItems[aggregateType].Add(id, aggregate);
+            }
+            finally
+            {
+                _syncLock.Release();
+            }
+        }
+
+        public void Detach<TAggregate>(TAggregate aggregate) where TAggregate : IAggregateRoot
+        {
+            _syncLock.Wait();
+
+            try
+            {
+                var aggregateType = typeof(TAggregate);
+                SetupAggregateInfo(aggregateType);
+
+                var id = GetId(aggregate);
+
+                var itemExists = _allTrackedItems[aggregateType].TryGetValue(id, out var result);
+                if (itemExists)
+                {
+                    _allTrackedItems[aggregateType].Remove(id);
+                }
+                else
+                {
+                    throw new ArgumentException("Item with the same id is not tracked", nameof(aggregate));
+                }
+            }
+            finally
+            {
+                _syncLock.Release();
+            }
+        }
+
+        public async Task SaveAsync()
+        {
+            await _syncLock.WaitAsync();
+
+            try
+            {
+                foreach (var t in _allTrackedItems)
+                {
+                    var saveMethod = _repositorySaveMethods[t.Key];
+                    foreach (var keyValuePair in t.Value)
+                    {
+                        await (Task)saveMethod(keyValuePair.Value);
+                    }
+                }
+            }
+            finally
+            {
+                _syncLock.Release();
+            }
+        }
+
+        public void DetachAll()
+        {
+            _syncLock.Wait();
+
+            try
+            {
+                foreach (var t in _allTrackedItems)
+                {
+                    t.Value.Clear();
+                }
+            }
+            finally
+            {
+                _syncLock.Release();
+            }
+        }
+
+        private void SetupAggregateInfo(Type aggregateType)
+        {
+            if (_aggregateInformationCache.ContainsKey(aggregateType))
+            {
+                return;
+            }
+
+            var result = aggregateType.GetAggregateInformation();
+            if (!result.IsValidResult)
+            {
+                throw new ArgumentException("The type is not a valid AggregateType", nameof(aggregateType));
+            }
+
+            var repositoryType =
+                typeof(IRepository<,,>).MakeGenericType(result.Aggregate, result.AggregateKey, result.EventKey);
+            var repository = _factory(repositoryType);
+
+            if (repository == null)
+            {
+                throw new ArgumentException($"No repository implementation for {repositoryType.Name} could be found", nameof(aggregateType));
+            }
+
+            repository = repositoryType.Cast(repository); // convert to type of interface
+
+            _aggregateInformationCache.Add(aggregateType, result);
+            _repositoryGetByIdMethods.Add(aggregateType, id =>
+                {
+                    var genericMethod = repositoryType.GetMethod(nameof(IRepository<MockAggregate, Guid, Guid>.GetByIdAsync));
+                    return genericMethod.Invoke(repository, new[] { id });
+                });
+
+            _repositorySaveMethods.Add(aggregateType, aggregate =>
+            {
+                var genericMethod = repositoryType.GetMethod(nameof(IRepository<MockAggregate, Guid, Guid>.SaveAsync));
+                return (Task)genericMethod.Invoke(repository, new[] { aggregate });
+            });
+
+            _allTrackedItems.Add(aggregateType, new Dictionary<object, object>());
+        }
+
+        private static object GetId<TAggregate>(TAggregate aggregate) where TAggregate : IAggregateRoot
+        {
+            var id = typeof(TAggregate).GetProperty(nameof(MockAggregate.Id)).GetMethod.Invoke(aggregate, null);
+            return id;
+        }
+    }
+}

--- a/src/NEventLite/Repository/Session.cs
+++ b/src/NEventLite/Repository/Session.cs
@@ -130,6 +130,7 @@ namespace NEventLite.Repository
         public void Dispose()
         {
            _trackedItems.Clear();
+           _syncLock?.Dispose();
         }
     }
 }

--- a/src/NEventLite/Util/AggregateInformation.cs
+++ b/src/NEventLite/Util/AggregateInformation.cs
@@ -29,6 +29,7 @@ namespace NEventLite.Util
 
         public static AggregateInformation ValidResult(Type aggregate, Type aggregateKey, Type eventKey, Type snapshot, Type snapshotKey) 
             => new AggregateInformation(aggregate, aggregateKey, eventKey, snapshot, snapshotKey);
+
         public static AggregateInformation InvalidResult => new AggregateInformation();
     }
 }

--- a/src/NEventLite/Util/ReflectionHelper.cs
+++ b/src/NEventLite/Util/ReflectionHelper.cs
@@ -2,6 +2,7 @@
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
+using System.Linq.Expressions;
 using System.Reflection;
 using System.Threading.Tasks;
 using NEventLite.Core;
@@ -104,6 +105,17 @@ namespace NEventLite.Util
         public static MemberInfo[] GetMembers(Type t)
         {
             return t.GetTypeInfo().DeclaredMembers.ToArray();
+        }
+
+        // Use this method to cast types that are not IConvertible
+        public static object Cast(this Type Type, object data)
+        {
+            var DataParam = Expression.Parameter(typeof(object), "data");
+            var Body = Expression.Block(Expression.Convert(Expression.Convert(DataParam, data.GetType()), Type));
+
+            var Run = Expression.Lambda(Body, DataParam).Compile();
+            var ret = Run.DynamicInvoke(data);
+            return ret;
         }
     }
 }

--- a/src/Samples/NEventLite.Samples.Autofac/NEventLiteModule.cs
+++ b/src/Samples/NEventLite.Samples.Autofac/NEventLiteModule.cs
@@ -41,7 +41,9 @@ namespace NEventLite.Samples.Autofac
             builder.Register(c => new InMemorySnapshotStorageProvider(SnapshotFrequency, inMemorySnapshotStorePath))
                 .As<ISnapshotStorageProvider<Guid>>().InstancePerLifetimeScope();
 
-            builder.ScanAndRegisterAggregates();
+            builder
+                .ScanAndRegisterAggregates()
+                .RegisterMasterSession();
 
             //Or add the repository registration manually
             //builder.RegisterType<Repository<Schedule, ScheduleSnapshot, Guid, Guid, Guid>>().As<IRepository<Schedule, Guid, Guid>>().InstancePerLifetimeScope();

--- a/src/Samples/NEventLite.Samples.Common/Handlers/CompleteTodoHandler.cs
+++ b/src/Samples/NEventLite.Samples.Common/Handlers/CompleteTodoHandler.cs
@@ -5,26 +5,9 @@ using NEventLite.Samples.Common.Domain.Schedule;
 
 namespace NEventLite.Samples.Common.Handlers
 {
-    //public class CompleteTodoHandler
-    //{
-    //    private readonly ISession<Schedule> _session;
-
-    //    public CompleteTodoHandler(ISession<Schedule> session)
-    //    {
-    //        _session = session;
-    //    }
-
-    //    public async Task HandleAsync(Guid scheduleId, Guid todoId)
-    //    {
-    //        var schedule = await _session.GetByIdAsync(scheduleId);
-    //        await schedule.CompleteTodoAsync(todoId);
-    //        await _session.SaveAsync();
-    //    }
-    //}
-
     public class CompleteTodoHandler
     {
-        private readonly IMasterSession _session;
+        private readonly IMasterSession _session; // This examples use the IMasterSession
 
         public CompleteTodoHandler(IMasterSession session)
         {

--- a/src/Samples/NEventLite.Samples.Common/Handlers/CompleteTodoHandler.cs
+++ b/src/Samples/NEventLite.Samples.Common/Handlers/CompleteTodoHandler.cs
@@ -5,18 +5,35 @@ using NEventLite.Samples.Common.Domain.Schedule;
 
 namespace NEventLite.Samples.Common.Handlers
 {
+    //public class CompleteTodoHandler
+    //{
+    //    private readonly ISession<Schedule> _session;
+
+    //    public CompleteTodoHandler(ISession<Schedule> session)
+    //    {
+    //        _session = session;
+    //    }
+
+    //    public async Task HandleAsync(Guid scheduleId, Guid todoId)
+    //    {
+    //        var schedule = await _session.GetByIdAsync(scheduleId);
+    //        await schedule.CompleteTodoAsync(todoId);
+    //        await _session.SaveAsync();
+    //    }
+    //}
+
     public class CompleteTodoHandler
     {
-        private readonly ISession<Schedule> _session;
+        private readonly IMasterSession _session;
 
-        public CompleteTodoHandler(ISession<Schedule> session)
+        public CompleteTodoHandler(IMasterSession session)
         {
             _session = session;
         }
 
         public async Task HandleAsync(Guid scheduleId, Guid todoId)
         {
-            var schedule = await _session.GetByIdAsync(scheduleId);
+            var schedule = await _session.GetByIdAsync<Schedule>(scheduleId);
             await schedule.CompleteTodoAsync(todoId);
             await _session.SaveAsync();
         }

--- a/src/Samples/NEventLite.Samples.ConsoleApp/DependencyInjection.cs
+++ b/src/Samples/NEventLite.Samples.ConsoleApp/DependencyInjection.cs
@@ -65,7 +65,9 @@ namespace NEventLite.Samples.ConsoleApp
             //services.AddScoped<ISession<Schedule, Guid, Guid>, Session<Schedule>>();
 
             // or add the by scanning for all aggregate types
-            services.ScanAndRegisterAggregates();
+            services
+                .ScanAndRegisterAggregates()
+                .RegisterMasterSession();
 
             services.AddScoped<CreateScheduleHandler>();
             services.AddScoped<CreateTodoHandler>();


### PR DESCRIPTION
The Current ISession<TAggregate> is scoped per aggregate type. This follows the best practice of generally not mutating more than one type of Aggregate per command in CQRS/CQS.

The master session extends the session/unit-of-work pattern across multiple aggregate types for special situations where this might be required.